### PR TITLE
Fix error when running `python -m orffinder ...` by giving `orffinder` an entry point

### DIFF
--- a/src/orffinder/__main__.py
+++ b/src/orffinder/__main__.py
@@ -1,0 +1,14 @@
+from .orffinder import *
+
+if __name__ == "__main__":
+    if len(sys.argv) < 4:
+        exit("Usage: python3 orffinder.py reference_genomes.fasta query_sequences.fasta [best|all]")
+    genome, query = sys.argv[1], sys.argv[2]
+    runtypes = ["best", "all"]
+    runtype = sys.argv[3]
+    if runtype not in runtypes:
+        exit("Error: Unrecognised run type: " + runtype)
+    if runtype == "best":
+        OrfFinder(genome, query).bestOrf()
+    elif runtype == "all":
+        OrfFinder(genome, query).allGoodOrfs()

--- a/src/orffinder/orffinder.py
+++ b/src/orffinder/orffinder.py
@@ -487,16 +487,3 @@ class Fasta:
     
     def fasta(self):
         return "\n".join([">" + x[0] + "\n" + x[1] for x in self.sequences.items()])
-
-if __name__ == "__main__":
-    if len(sys.argv) < 4:
-        exit("Usage: python3 orffinder.py reference_genomes.fasta query_sequences.fasta [best|all]")
-    genome, query = sys.argv[1], sys.argv[2]
-    runtypes = ["best", "all"]
-    runtype = sys.argv[3]
-    if runtype not in runtypes:
-        exit("Error: Unrecognised run type: " + runtype)
-    if runtype == "best":
-        OrfFinder(genome, query).bestOrf()
-    elif runtype == "all":
-        OrfFinder(genome, query).allGoodOrfs()


### PR DESCRIPTION
This fixes the error
```
No module named orffinder.__main__; 'orffinder' is a package and cannot be directly executed
```
when running `python -m orffinder ...` since the package did not have an entry point. It adds a `__main__.py` file to handle this.

Alternatively, we could instruct the package installer to create an `orffinder` executable script.