### PR TITLE
Use argparse to parse command line arguments

### DIFF
--- a/src/orffinder/__main__.py
+++ b/src/orffinder/__main__.py
@@ -5,7 +5,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Find open reading frames (ORFs) in the given sequence.")
     parser.add_argument('reference_genome', type=str, help="""The path to a FASTA file containing the reference genome used to cross-reference found ORFs against using tBLASTn.""")
     parser.add_argument('query_sequences', type=str, help="""The path to a FASTA file containing sequences ORFs should be found in. This could be e.g. a full genome or a set of mRNA sequences.""")
-    parser.add_argument('--mode', type=str, choices=['best', 'all'], default='all', help="The mode of operation: 'best' finds the best ORF in a given sequence, while 'all' finds all possible non-overlapping ORFs in a given sequence. Default is 'all'.")
+    parser.add_argument('--mode', type=str, choices=['best', 'all'], default='all', help="The mode of operation: 'best' finds the best ORF in a given sequence, while 'all' finds all good non-overlapping ORFs in a given sequence (see the documentation for details). Default is 'all'.")
 
     args = parser.parse_args()
     print()

--- a/src/orffinder/__main__.py
+++ b/src/orffinder/__main__.py
@@ -1,14 +1,16 @@
 from .orffinder import *
+import argparse
 
 if __name__ == "__main__":
-    if len(sys.argv) < 4:
-        exit("Usage: python3 orffinder.py reference_genomes.fasta query_sequences.fasta [best|all]")
-    genome, query = sys.argv[1], sys.argv[2]
-    runtypes = ["best", "all"]
-    runtype = sys.argv[3]
-    if runtype not in runtypes:
-        exit("Error: Unrecognised run type: " + runtype)
-    if runtype == "best":
-        OrfFinder(genome, query).bestOrf()
-    elif runtype == "all":
-        OrfFinder(genome, query).allGoodOrfs()
+    parser = argparse.ArgumentParser(description="Find open reading frames (ORFs) in the given sequence.")
+    parser.add_argument('reference_genome', type=str, help="""The path to a FASTA file containing the reference genome used to cross-reference found ORFs against using tBLASTn.""")
+    parser.add_argument('query_sequences', type=str, help="""The path to a FASTA file containing sequences ORFs should be found in. This could be e.g. a full genome or a set of mRNA sequences.""")
+    parser.add_argument('--mode', type=str, choices=['best', 'all'], default='all', help="The mode of operation: 'best' finds the best ORF in a given sequence, while 'all' finds all possible non-overlapping ORFs in a given sequence. Default is 'all'.")
+
+    args = parser.parse_args()
+    print()
+    orffinder = OrfFinder(args.reference_genome, args.query_sequences)
+    if args.mode == "best":
+        results = orffinder.bestOrf()
+    elif args.mode == "all":
+        results = orffinder.allGoodOrfs()


### PR DESCRIPTION
This is so we can
a) have a helpful message when running `python -m orffinder --help`; and
b) prepares the path to having different output formats depending on given command line outputs.